### PR TITLE
feat: support streaming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rosnik"
-version = "0.0.26"
+version = "0.0.27"
 description = "ROSNIK Python SDK"
 authors = ["Nick DiRienzo <nick@rosnik.ai>"]
 license = "MIT"

--- a/rosnik/providers/openai.py
+++ b/rosnik/providers/openai.py
@@ -73,7 +73,9 @@ def request_hook(
         ai_metadata=metadata,
         request_payload=payload,
         user_id=user_id,
-        _metadata=Metadata(function_fingerprint=function_fingerprint, stream=payload.get("stream", False)),
+        _metadata=Metadata(
+            function_fingerprint=function_fingerprint, stream=payload.get("stream", False)
+        ),
     )
     queue.enqueue_event(event)
     return event

--- a/rosnik/providers/openai.py
+++ b/rosnik/providers/openai.py
@@ -1,14 +1,16 @@
 import functools
 import logging
 import time
-from typing import Callable
+from typing import Callable, Iterator, Union
 
 from rosnik import constants
+from rosnik.events import queue
 from rosnik.types.core import AIEvent, Metadata
 from rosnik.wrap import wrap_class_method
 from rosnik.types.ai import (
     AIFunctionMetadata,
     AIRequestFinish,
+    AIRequestFirstChunk,
     AIRequestStart,
     ErrorResponseData,
     OpenAIAttributes,
@@ -24,14 +26,14 @@ logger = logging.getLogger(__name__)
 _OAI = "openai"
 
 
-def serializer_with_metadata(
-    serializer: Callable, generate_metadata: Callable[[], AIFunctionMetadata]
+def hook_with_metadata(
+    hook: Callable, generate_metadata: Callable[[], AIFunctionMetadata]
 ):
     """Each provider should be encapsulated into what it knows about the call."""
-    return functools.partial(serializer, generate_metadata=generate_metadata)
+    return functools.partial(hook, generate_metadata=generate_metadata)
 
 
-def request_serializer(
+def request_hook(
     payload: dict,
     function_fingerprint: str,
     prior_event: AIEvent = None,
@@ -66,7 +68,7 @@ def request_serializer(
     )
     user_id = payload.get("user")
 
-    return AIRequestStart(
+    event = AIRequestStart(
         ai_model=ai_model,
         ai_provider=metadata.ai_provider,
         ai_action=metadata.ai_action,
@@ -75,14 +77,20 @@ def request_serializer(
         user_id=user_id,
         _metadata=Metadata(function_fingerprint=function_fingerprint),
     )
+    queue.enqueue_event(event)
+    return event
 
 
-def response_serializer(
-    payload: "OpenAIObject",
+def response_hook(
+    payload: Union["OpenAIObject", Iterator],
     function_fingerprint: str,
     prior_event: AIEvent = None,
     generate_metadata: Callable[[], AIFunctionMetadata] = None,
 ) -> AIRequestFinish:
+    """If we're an Iterator, it means we're a streamed response,
+    in which case we're tracking first-byte here.
+    If we're an OpenAIObject, then we can provide additional metadata.
+    """
     if not payload:
         return None
 
@@ -93,8 +101,8 @@ def response_serializer(
     # Reimport to make sure we have the latest values
     import openai
 
-    # For both OpenAI and Azure, `model` contains the model on the response.
-    ai_model = payload.get("model")
+    is_stream_response = isinstance(payload, Iterator)
+
     metadata = generate_metadata()
     metadata.openai_attributes = OpenAIAttributes(
         api_base=openai.api_base,
@@ -104,22 +112,117 @@ def response_serializer(
     )
 
     now = int(time.time_ns() / 1000000)
-    return AIRequestFinish(
-        ai_model=ai_model,
-        ai_provider=metadata.ai_provider,
-        ai_action=metadata.ai_action,
-        ai_metadata=metadata,
-        response_payload=payload,
-        # Explicitly set this so that response_ms is stable.
-        sent_at=now,
-        response_ms=(now - prior_event.sent_at),
-        ai_request_start_event_id=prior_event.event_id,
-        user_id=prior_event.user_id,
-        _metadata=Metadata(function_fingerprint=function_fingerprint),
-    )
+    event_kwargs = {
+        # For both OpenAI and Azure, `model` contains the model on the response.
+        'ai_model': prior_event.ai_model if is_stream_response else payload.get("model"),
+        'ai_provider': metadata.ai_provider,
+        'ai_action': metadata.ai_action,
+        'ai_metadata': metadata,
+        'response_payload': payload,
+        'sent_at': now,
+        'response_ms': (now - prior_event.sent_at),
+        'ai_request_start_event_id': prior_event.event_id,
+        'user_id': prior_event.user_id,
+        '_metadata': Metadata(function_fingerprint=function_fingerprint),
+    }
+
+    if is_stream_response:
+        # These don't exist. `payload` is a generator.
+        # Make this None
+        event_kwargs.pop("response_payload")
+        event = AIRequestFirstChunk(**event_kwargs)
+        queue.enqueue_event(event)
+        return event
+
+    event = AIRequestFinish(**event_kwargs)
+    queue.enqueue_event(event)
+    return event
 
 
-def error_serializer(
+def streamed_response_hook(
+    response: Iterator,
+    function_fingerprint: str,
+    prior_event: AIEvent = None,
+    generate_metadata: Callable[[], AIFunctionMetadata] = None,
+):
+    """Wrap the response generator with our own function so that the
+    user can still yield results, and we can automatically
+    figure out the duration of the stream.
+    """
+
+    content_parts = []
+    # Load openai here and use values defined at this point.
+    import openai
+
+    def _stream_hook(line: "OpenAIObject"):
+        """For each chunk, either add it to our content_parts
+        or emit an event because we're done.
+        """
+        # TODO: what do we do here
+        if not line:
+            return
+
+        choices = line.get("choices")
+        if not choices or len(choices) < 1:
+            # TODO: And here
+            return
+
+        content = choices[0].get("delta", {}).get("content")
+        if content:
+            content_parts.append(content)
+
+        finish_reason = choices[0].get("finish_reason")
+        if finish_reason:
+            metadata = generate_metadata()
+            metadata.openai_attributes = OpenAIAttributes(
+                api_base=openai.api_base,
+                api_type=openai.api_type,
+                api_version=openai.api_version,
+                organization=openai.organization,
+            )
+            now = int(time.time_ns() / 1000000)
+            finish_event = AIRequestFinish(
+                ai_model=line.get("model"),
+                ai_provider=metadata.ai_provider,
+                ai_action=metadata.ai_action,
+                ai_metadata=metadata,
+                # Mimic the OpenAI response payload.
+                # Missing `usage`, TODO: what do?
+                response_payload={
+                    "streamed_response": True,
+                    "choices": [
+                        {
+                            "finish_reason": finish_reason,
+                            "index": 0,
+                            "message": {"content": "".join(content_parts), "role": "assistant"},
+                        }
+                    ],
+                    "model": line.get("model"),
+                    "created": line.get("created"),
+                    "object": line.get("object"),
+                    "id": line.get("id"),
+                },
+                sent_at=now,
+                response_ms=(now - prior_event.sent_at),
+                ai_request_start_event_id=prior_event.event_id,
+                user_id=prior_event.user_id,
+                _metadata=Metadata(function_fingerprint=function_fingerprint),
+            )
+            queue.enqueue_event(finish_event)
+
+        # TODO: and here
+        if not isinstance(content, str):
+            return
+
+    def _stream_response_wrapper(response: Iterator):
+        for line in response:
+            _stream_hook(line)
+            yield line
+
+    return _stream_response_wrapper(response)
+
+
+def error_hook(
     error: Exception,
     function_fingerprint: str,
     prior_event: AIEvent = None,
@@ -143,7 +246,7 @@ def error_serializer(
     )
 
     now = int(time.time_ns() / 1000000)
-    return AIRequestFinish(
+    event = AIRequestFinish(
         ai_model=None,
         ai_provider=metadata.ai_provider,
         ai_action=metadata.ai_action,
@@ -160,6 +263,8 @@ def error_serializer(
         user_id=prior_event.user_id,
         _metadata=Metadata(function_fingerprint=function_fingerprint),
     )
+    queue.enqueue_event(event)
+    return event
 
 
 def _patch_completion(openai):
@@ -170,17 +275,20 @@ def _patch_completion(openai):
     wrap_class_method(
         openai.Completion,
         "create",
-        serializer_with_metadata(
-            request_serializer,
+        hook_with_metadata(
+            request_hook,
             lambda: AIFunctionMetadata(ai_provider=_OAI, ai_action="completions"),
         ),
-        serializer_with_metadata(
-            response_serializer,
+        hook_with_metadata(
+            response_hook,
             lambda: AIFunctionMetadata(ai_provider=_OAI, ai_action="completions"),
         ),
-        serializer_with_metadata(
-            error_serializer, lambda: AIFunctionMetadata(ai_provider=_OAI, ai_action="completions")
+        hook_with_metadata(
+            error_hook, lambda: AIFunctionMetadata(ai_provider=_OAI, ai_action="completions")
         ),
+        hook_with_metadata(
+            streamed_response_hook, lambda: AIFunctionMetadata(ai_provider=_OAI, ai_action="completions")
+        )
     )
 
 
@@ -192,16 +300,20 @@ def _patch_chat_completion(openai):
     wrap_class_method(
         openai.ChatCompletion,
         "create",
-        serializer_with_metadata(
-            request_serializer,
+        hook_with_metadata(
+            request_hook,
             lambda: AIFunctionMetadata(ai_provider=_OAI, ai_action="chat.completions"),
         ),
-        serializer_with_metadata(
-            response_serializer,
+        hook_with_metadata(
+            response_hook,
             lambda: AIFunctionMetadata(ai_provider=_OAI, ai_action="chat.completions"),
         ),
-        serializer_with_metadata(
-            error_serializer,
+        hook_with_metadata(
+            error_hook,
+            lambda: AIFunctionMetadata(ai_provider=_OAI, ai_action="chat.completions"),
+        ),
+        hook_with_metadata(
+            streamed_response_hook,
             lambda: AIFunctionMetadata(ai_provider=_OAI, ai_action="chat.completions"),
         ),
     )

--- a/rosnik/providers/openai.py
+++ b/rosnik/providers/openai.py
@@ -158,13 +158,13 @@ def streamed_response_hook(
         """For each chunk, either add it to our content_parts
         or emit an event because we're done.
         """
-        # TODO: what do we do here
         if not line:
+            logger.debug("Line not seen on stream.")
             return
 
         choices = line.get("choices")
         if not choices or len(choices) < 1:
-            # TODO: And here
+            logger.debug("Missing choices on stream.")
             return
 
         content = choices[0].get("delta", {}).get("content")

--- a/rosnik/types/ai.py
+++ b/rosnik/types/ai.py
@@ -45,7 +45,7 @@ class AIFunctionMetadata(DataClassJsonMixin):
 @dataclass(kw_only=True, slots=True)
 class AIRequestStart(AIEvent):
     event_type: str = "ai.request.start"
-    # JSONable request payload
+    # JSONable request payload / kwargs sent through the SDK
     request_payload: dict
     ai_metadata: AIFunctionMetadata
 
@@ -65,6 +65,12 @@ class AIRequestFinish(AIEvent):
     response_ms: int
     # null on success
     error_data: Optional[ErrorResponseData] = None
+
+@dataclass(kw_only=True, slots=True)
+class AIRequestFirstChunk(AIRequestFinish):
+    """One-off event used to track first-byte time.
+    """
+    event_type: str = "ai.request.first_chunk"
 
 
 @dataclass(kw_only=True, slots=True)

--- a/rosnik/types/ai.py
+++ b/rosnik/types/ai.py
@@ -66,11 +66,11 @@ class AIRequestFinish(AIEvent):
     # null on success
     error_data: Optional[ErrorResponseData] = None
 
+
 @dataclass(kw_only=True, slots=True)
-class AIRequestFirstChunk(AIRequestFinish):
-    """One-off event used to track first-byte time.
-    """
-    event_type: str = "ai.request.first_chunk"
+class AIRequestStartStream(AIRequestFinish):
+    """One-off event used to track first-byte time."""
+    event_type: str = "ai.request.start.stream"
 
 
 @dataclass(kw_only=True, slots=True)

--- a/rosnik/types/ai.py
+++ b/rosnik/types/ai.py
@@ -70,6 +70,7 @@ class AIRequestFinish(AIEvent):
 @dataclass(kw_only=True, slots=True)
 class AIRequestStartStream(AIRequestFinish):
     """One-off event used to track first-byte time."""
+
     event_type: str = "ai.request.start.stream"
 
 

--- a/rosnik/types/core.py
+++ b/rosnik/types/core.py
@@ -20,7 +20,7 @@ class StaticMetadata:
     runtime: str = platform.python_implementation()
     runtime_version: str = platform.python_version()
     # TODO: how to sync pyproject version to this
-    sdk_version: str = "0.0.26"
+    sdk_version: str = "0.0.27"
 
 
 @dataclass(kw_only=True, slots=True)

--- a/rosnik/types/core.py
+++ b/rosnik/types/core.py
@@ -26,6 +26,7 @@ class StaticMetadata:
 @dataclass(kw_only=True, slots=True)
 class Metadata(StaticMetadata):
     function_fingerprint: str
+    stream: bool = False
 
 
 @dataclass(kw_only=True, slots=True)

--- a/rosnik/wrap.py
+++ b/rosnik/wrap.py
@@ -4,7 +4,6 @@ import sys
 from typing import Callable
 
 
-from rosnik.events import queue
 
 import wrapt
 

--- a/rosnik/wrap.py
+++ b/rosnik/wrap.py
@@ -33,27 +33,30 @@ def get_stack_frames(num, use_get_frame=True):
 def wrap_class_method(
     klass,
     method_name: str,
-    request_serializer: Callable,
-    response_serializer: Callable,
-    error_serializer: Callable,
+    request_hook: Callable,
+    response_hook: Callable,
+    error_hook: Callable,
+    streamed_response_hook: Callable,
 ):
     def wrapper(wrapped, instance, args, kwargs):
         limited_frames = get_stack_frames(5)
         # Flatten into a period separated sequence so we can do function chain search later.
         calling_functions = ".".join([frame.f_code.co_name for frame in limited_frames])
 
-        # TODO: support streaming.
-        request_event = request_serializer(kwargs, calling_functions)
-        queue.enqueue_event(request_event)
+        request_event = request_hook(kwargs, calling_functions)
         try:
             result = wrapped(*args, **kwargs)
         except Exception as e:
-            error_event = error_serializer(e, calling_functions, request_event)
-            queue.enqueue_event(error_event)
+            error_hook(e, calling_functions, request_event)
             raise e
 
-        request_finish = response_serializer(result, calling_functions, prior_event=request_event)
-        queue.enqueue_event(request_finish)
+        response_hook(result, calling_functions, prior_event=request_event)
+
+        # If this is a streamed output, wrap this so we can capture stream duration
+        # and final output.
+        if kwargs.get("stream") is True:
+            return streamed_response_hook(result, calling_functions, prior_event=request_event)
+
         return result
 
     wrapt.wrap_function_wrapper(klass, method_name, wrapper)

--- a/rosnik/wrap.py
+++ b/rosnik/wrap.py
@@ -4,7 +4,6 @@ import sys
 from typing import Callable
 
 
-
 import wrapt
 
 logger = logging.getLogger(__name__)

--- a/tests/cassettes/test_openai/test_chat_completion__streaming.yaml
+++ b/tests/cassettes/test_openai/test_chat_completion__streaming.yaml
@@ -1,0 +1,1614 @@
+interactions:
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "\n    You
+      are an aspiring edm artist. \n    Generate a song using words, for example \"uhn
+      tiss uhn tiss\", that give the impression of an edm song.\n    Your inspiration
+      is the artist provided by the user.\n    "}, {"role": "user", "content": "Daft
+      Punk"}], "stream": true}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '345'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"("},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Verse"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        "},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"1"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":")\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"We"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''re"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        up"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        all"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        night"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        to"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        get"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        lucky"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        lucky"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        lucky"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"In"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        a"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        digital"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        world"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        feeling"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        oh"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        so"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        funky"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        funky"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        funky"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Rob"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"otic"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        melodies"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        electr"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ifying"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        beats"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Da"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ft"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Punk"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        bringing"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        heat"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        heat"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        heat"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"("},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Ch"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"orus"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":")\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"We"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''re"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        robots"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        of"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        dance"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"floor"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        working"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        it"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        all"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        night"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        long"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Feel"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        th"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"umping"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        bass"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        it"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''s"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        a"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Da"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ft"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Punk"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        song"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Hands"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        in"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        air"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        come"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        on"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        let"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''s"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        go"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Jump"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        to"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        rhythm"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        lose"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        control"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        here"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        we"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        go"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"!\n\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"("},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Verse"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        "},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"2"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":")\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Hard"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"er"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        better"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        faster"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        stronger"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        that"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''s"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        way"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        we"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        move"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"In"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        a"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        neon"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        rave"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        feel"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        groove"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        groove"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        groove"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"One"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        more"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        time"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        rock"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        house"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        make"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        crowd"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        go"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        wild"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Da"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ft"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Punk"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        in"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        mix"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        let"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''s"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        party"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        we"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''re"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        on"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        style"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"("},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Ch"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"orus"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":")\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"We"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''re"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        robots"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        of"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        dance"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"floor"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        working"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        it"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        all"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        night"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        long"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Feel"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        th"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"umping"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        bass"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        it"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''s"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        a"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Da"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ft"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Punk"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        song"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Hands"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        in"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        air"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        come"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        on"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        let"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''s"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        go"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Jump"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        to"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        rhythm"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        lose"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        control"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        here"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        we"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        go"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"!\n\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"(B"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ridge"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":")\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Inter"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"stellar"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        funk"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        taking"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        us"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        higher"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Da"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ft"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Punk"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''s"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        sound"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        will"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        never"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        tire"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Lights"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        flashing"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        bodies"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        moving"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        in"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        sync"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"This"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        electric"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        vibe"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        let"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        it"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        sink"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        sink"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        sink"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"(D"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"rop"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":")\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"U"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"hn"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        t"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"iss"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        u"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"hn"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        t"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"iss"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        feel"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        beat"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        puls"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ating"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"U"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"hn"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        t"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"iss"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        u"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"hn"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        t"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"iss"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        crowd"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        is"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        celebrating"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"U"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"hn"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        t"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"iss"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        u"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"hn"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        t"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"iss"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        hands"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        up"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        in"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        air"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Da"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ft"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Punk"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''s"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        music"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        we"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        just"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        can"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''t"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        compare"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"("},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Ch"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"orus"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":")\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"We"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''re"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        robots"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        of"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        dance"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"floor"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        working"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        it"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        all"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        night"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        long"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Feel"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        th"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"umping"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        bass"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        it"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''s"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        a"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Da"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ft"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Punk"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        song"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Hands"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        in"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        air"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        come"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        on"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        let"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''s"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        go"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Jump"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        to"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        rhythm"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        lose"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        control"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        here"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        we"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        go"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"!\n\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"("},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Out"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ro"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":")\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Thank"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        you"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Da"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ft"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Punk"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        for"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        inspiration"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Your"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        music"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        brings"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        us"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        pure"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        el"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ation"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ED"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"M"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        forever"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        we"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''ll"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        keep"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        dancing"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        strong"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"In"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        spirit"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        of"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Da"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ft"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Punk"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        we"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"''ll"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        carry"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        on"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"."},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8AV2vH5VlWpKSkEvfMTgwxWR3iEGS","object":"chat.completion.chunk","created":1697513313,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 817573bf5bb7cfb8-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Tue, 17 Oct 2023 03:28:33 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '5'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89928'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 48ms
+      x-request-id:
+      - d3add86e8ca3969473b8d7ef158cfdc3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_openai/test_chat_completion__streaming__azure.yaml
+++ b/tests/cassettes/test_openai/test_chat_completion__streaming__azure.yaml
@@ -1,0 +1,1836 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "system", "content": "\n    You are an aspiring
+      edm artist. \n    Generate a song using words, for example \"uhn tiss uhn tiss\",
+      that give the impression of an edm song.\n    Your inspiration is the artist
+      provided by the user.\n    "}, {"role": "user", "content": "Daft Punk"}], "stream":
+      true}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '319'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+      api-key:
+      - abf1a77cb46e41a7be9e1e961c9c4629
+    method: POST
+    uri: https://rosnik.openai.azure.com//openai/deployments/gpt-35-turbo/chat/completions?api-version=2023-05-15
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"("}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Verse"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        "}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"1"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Rob"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"otic"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        rhythms"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        puls"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ing"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        through"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        my"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        veins"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Da"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ft"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        Punk"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        vibes"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        driving"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        me"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        insane"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Be"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ats"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        so"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        infectious"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        they"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''re"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        taking"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        control"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"L"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ose"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        myself"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        in"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        sound"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        let"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        music"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        unfold"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"("}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Pre"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"-Ch"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"orus"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Electric"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        energy"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        I"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        can"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        feel"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        it"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        in"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        air"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Da"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ft"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        Punk"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        legacy"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        I"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''m"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        here"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        to"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        declare"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Hands"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        up"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        in"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        sky"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        we"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''re"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        all"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        feeling"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        groove"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Join"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        dance"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        floor"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        let"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        music"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        soo"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"("}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Ch"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"orus"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"We"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''re"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        gonna"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        party"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        like"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        it"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        future"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Da"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ft"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        Punk"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        beats"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        nothing"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        can"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        mute"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        ya"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"B"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"urst"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        of"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        electronic"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        magic"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        so"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        surreal"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"We"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''ll"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        dance"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        till"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        morning"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        this"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        is"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        how"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        we"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        feel"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"(U"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"hn"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        t"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"iss"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        u"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"hn"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        t"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"iss"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"("}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Verse"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        "}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"2"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Syn"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ths"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        and"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        voc"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"oders"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        a"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        signature"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        sound"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Da"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ft"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        Punk"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        melodies"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        they"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        always"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        ast"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ound"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"We"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''re"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        all"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        robots"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        lost"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        in"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        neon"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        haze"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Moving"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        to"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        beat"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        in"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        this"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        electr"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ified"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        maze"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"("}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Pre"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"-Ch"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"orus"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"The"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        bass"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        is"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        pounding"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        creating"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        ecstasy"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Da"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ft"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        Punk"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        influence"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        it"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        has"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        set"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        us"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        free"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Lights"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        flashing"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        colors"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        swirling"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        all"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        around"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"This"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        EDM"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        journey"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        unstoppable"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        and"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        profound"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"("}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Ch"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"orus"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"We"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''re"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        gonna"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        party"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        like"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        it"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        future"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Da"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ft"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        Punk"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        beats"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        nothing"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        can"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        mute"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        ya"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"B"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"urst"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        of"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        electronic"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        magic"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        so"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        surreal"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"We"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''ll"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        dance"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        till"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        morning"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        this"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        is"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        how"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        we"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        feel"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"(U"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"hn"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        t"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"iss"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        u"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"hn"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        t"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"iss"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"(B"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ridge"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Hands"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        in"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        air"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        let"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        music"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        guide"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Da"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ft"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        Punk"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        legacy"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        forever"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        we"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''ll"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        ride"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"The"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        energy"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        rising"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        we"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''re"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        reaching"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        new"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        heights"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Lost"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        in"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        sound"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        this"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        is"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        our"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        dream"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        ignite"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"(D"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"rop"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"U"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"hn"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        t"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"iss"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        u"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"hn"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        t"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"iss"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        beat"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        goes"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        on"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"We"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''re"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        in"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        zone"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        where"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        nothing"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        can"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        go"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        wrong"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"U"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"hn"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        t"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"iss"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        u"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"hn"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        t"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"iss"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        let"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        rhythm"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        take"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        control"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Da"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ft"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        Punk"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        spirit"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        burning"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        in"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        our"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        souls"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"("}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Ch"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"orus"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"We"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''re"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        gonna"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        party"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        like"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        it"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        future"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Da"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ft"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        Punk"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        beats"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        nothing"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        can"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        mute"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        ya"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"B"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"urst"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        of"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        electronic"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        magic"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        so"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        surreal"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"We"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''ll"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        dance"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        till"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        morning"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        this"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        is"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        how"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        we"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        feel"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"(U"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"hn"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        t"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"iss"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        u"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"hn"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        t"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"iss"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"("}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Out"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ro"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":")\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"The"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        night"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        is"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        endless"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        music"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        never"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        stops"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Da"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"ft"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        Punk"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''s"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        influence"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        it"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        forever"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        rocks"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"As"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"piring"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        EDM"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        artists"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        we"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''ll"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        carry"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        the"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        flame"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"\n"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"In"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        this"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        electronic"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        world"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        we"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"''ll"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        make"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        our"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"
+        name"}}],"usage":null}
+
+
+        data: {"id":"chatcmpl-8AVDqMfgHnElrRdQgKaJFDAIbnyJP","object":"chat.completion.chunk","created":1697513990,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":"stop","delta":{}}],"usage":null}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache, must-revalidate
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Tue, 17 Oct 2023 03:39:49 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      apim-request-id:
+      - 171b6eb2-c53c-4fab-961b-f2b49e208291
+      azureml-model-session:
+      - d677b54a9b2c9-2
+      openai-processing-ms:
+      - '51.5577'
+      x-accel-buffering:
+      - 'no'
+      x-content-type-options:
+      - nosniff
+      x-ms-client-request-id:
+      - 171b6eb2-c53c-4fab-961b-f2b49e208291
+      x-ms-region:
+      - Sweden Central
+      x-request-id:
+      - 4e31d103-21bb-445b-b39f-347db432f421
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_ai_events.py
+++ b/tests/test_ai_events.py
@@ -18,7 +18,7 @@ def validate_common_attributes(event: Event):
     assert event._metadata.environment is None
     assert event._metadata.runtime == platform.python_implementation()
     assert event._metadata.runtime_version == platform.python_version()
-    assert event._metadata.sdk_version == "0.0.26"
+    assert event._metadata.sdk_version == "0.0.27"
     assert event._metadata.function_fingerprint
     assert len(event._metadata.function_fingerprint.split(".")) == 5
 

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -184,6 +184,68 @@ def test_chat_completion__azure__engine(openai, event_queue):
     assert request_finish.ai_metadata.openai_attributes.api_type == expected_api_type
     assert request_finish.ai_metadata.openai_attributes.api_version == expected_api_version
 
+@pytest.mark.vcr
+def test_chat_completion__streaming__azure(openai, event_queue):
+    system_prompt = """
+    You are an aspiring edm artist. 
+    Generate a song using words, for example "uhn tiss uhn tiss", that give the impression of an edm song.
+    Your inspiration is the artist provided by the user.
+    """
+    input_text = "Daft Punk"
+    expected_api_base = "https://rosnik.openai.azure.com/"
+    expected_api_type = "azure"
+    expected_api_version = "2023-05-15"
+    openai.api_key = os.environ.get("AZURE_API_KEY")
+    openai.api_base = expected_api_base
+    openai.api_type = expected_api_type
+    openai.api_version = expected_api_version
+    openai_._patch_chat_completion(openai)
+    assert event_queue.qsize() == 0
+    response = openai.ChatCompletion.create(
+        deployment_id="gpt-35-turbo",
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": input_text},
+        ],
+        stream=True,
+    )
+
+    expected_completion = ""
+    for line in response:
+        s = line["choices"][0].get("delta", {}).get("content")
+        if isinstance(s, str):
+            expected_completion += s
+
+    assert event_queue.qsize() == 3
+    request_start: AIRequestStart = event_queue.get()
+    assert request_start.ai_metadata.openai_attributes.api_base == expected_api_base
+    assert request_start.ai_metadata.openai_attributes.api_type == expected_api_type
+    assert request_start.ai_metadata.openai_attributes.api_version == expected_api_version
+
+    first_chunk_event: AIRequestFirstChunk = event_queue.get()
+    assert first_chunk_event.ai_metadata.openai_attributes.api_base == expected_api_base
+    assert first_chunk_event.ai_metadata.openai_attributes.api_type == expected_api_type
+    assert first_chunk_event.ai_metadata.openai_attributes.api_version == expected_api_version
+    assert first_chunk_event.response_ms == first_chunk_event.sent_at - request_start.sent_at
+    assert first_chunk_event.ai_request_start_event_id == request_start.event_id
+    assert first_chunk_event.ai_model == request_start.ai_model
+    assert first_chunk_event.ai_provider == openai_._OAI
+    assert first_chunk_event.ai_action == "chat.completions"
+    assert first_chunk_event.response_payload is None
+
+    request_finish: AIRequestFinish = event_queue.get()
+    assert request_finish.ai_metadata.openai_attributes.api_base == expected_api_base
+    assert request_finish.ai_metadata.openai_attributes.api_type == expected_api_type
+    assert request_finish.ai_metadata.openai_attributes.api_version == expected_api_version
+    assert request_finish.response_ms == request_finish.sent_at - request_start.sent_at
+    assert request_finish.ai_request_start_event_id == request_start.event_id
+    # Iterations know the more specific model.
+    assert request_finish.ai_model == "gpt-35-turbo"
+    assert request_finish.ai_provider == openai_._OAI
+    assert request_finish.ai_action == "chat.completions"
+    assert request_finish.response_payload["streamed_response"] is True
+    streamed_completion = request_finish.response_payload["choices"][0]["message"]["content"]
+    assert streamed_completion == expected_completion
 
 @pytest.mark.vcr
 def test_error(openai, event_queue):

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -3,7 +3,7 @@ import pytest
 from rosnik import constants
 
 from rosnik.providers import openai as openai_
-from rosnik.types.ai import AIFunctionMetadata, AIRequestFinish, AIRequestStart
+from rosnik.types.ai import AIFunctionMetadata, AIRequestFinish, AIRequestFirstChunk, AIRequestStart
 from rosnik.types.core import Metadata
 
 
@@ -58,6 +58,63 @@ def test_chat_completion(openai, event_queue):
     assert request_finish.ai_metadata.openai_attributes.api_base == "https://api.openai.com/v1"
     assert request_finish.ai_metadata.openai_attributes.api_type == "open_ai"
     assert request_finish.ai_metadata.openai_attributes.api_version is None
+
+
+@pytest.mark.vcr
+def test_chat_completion__streaming(openai, event_queue):
+    system_prompt = """
+    You are an aspiring edm artist. 
+    Generate a song using words, for example "uhn tiss uhn tiss", that give the impression of an edm song.
+    Your inspiration is the artist provided by the user.
+    """
+    input_text = "Daft Punk"
+    openai_._patch_chat_completion(openai)
+    assert event_queue.qsize() == 0
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": input_text},
+        ],
+        stream=True,
+    )
+
+    expected_completion = ""
+    for line in response:
+        s = line["choices"][0].get("delta", {}).get("content")
+        if isinstance(s, str):
+            expected_completion += s
+
+    assert event_queue.qsize() == 3
+    request_start: AIRequestStart = event_queue.get()
+    assert request_start.ai_metadata.openai_attributes.api_base == "https://api.openai.com/v1"
+    assert request_start.ai_metadata.openai_attributes.api_type == "open_ai"
+    assert request_start.ai_metadata.openai_attributes.api_version is None
+
+    first_chunk_event: AIRequestFirstChunk = event_queue.get()
+    assert first_chunk_event.ai_metadata.openai_attributes.api_base == "https://api.openai.com/v1"
+    assert first_chunk_event.ai_metadata.openai_attributes.api_type == "open_ai"
+    assert first_chunk_event.ai_metadata.openai_attributes.api_version is None
+    assert first_chunk_event.response_ms == first_chunk_event.sent_at - request_start.sent_at
+    assert first_chunk_event.ai_request_start_event_id == request_start.event_id
+    assert first_chunk_event.ai_model == request_start.ai_model
+    assert first_chunk_event.ai_provider == openai_._OAI
+    assert first_chunk_event.ai_action == "chat.completions"
+    assert first_chunk_event.response_payload is None
+
+    request_finish: AIRequestFinish = event_queue.get()
+    assert request_finish.ai_metadata.openai_attributes.api_base == "https://api.openai.com/v1"
+    assert request_finish.ai_metadata.openai_attributes.api_type == "open_ai"
+    assert request_finish.ai_metadata.openai_attributes.api_version is None
+    assert request_finish.response_ms == request_finish.sent_at - request_start.sent_at
+    assert request_finish.ai_request_start_event_id == request_start.event_id
+    # Iterations know the more specific model.
+    assert request_finish.ai_model == "gpt-3.5-turbo-0613"
+    assert request_finish.ai_provider == openai_._OAI
+    assert request_finish.ai_action == "chat.completions"
+    assert request_finish.response_payload["streamed_response"] is True
+    streamed_completion = request_finish.response_payload["choices"][0]["message"]["content"]
+    assert streamed_completion == expected_completion
 
 
 @pytest.mark.vcr
@@ -127,6 +184,7 @@ def test_chat_completion__azure__engine(openai, event_queue):
     assert request_finish.ai_metadata.openai_attributes.api_type == expected_api_type
     assert request_finish.ai_metadata.openai_attributes.api_version == expected_api_version
 
+
 @pytest.mark.vcr
 def test_error(openai, event_queue):
     system_prompt = "You are a helpful assistant." * 100000
@@ -156,8 +214,8 @@ def mock_openai_object(mocker):
     return openai_obj
 
 
-def test_request_serializer_valid_payload():
-    result = openai_.request_serializer(
+def test_request_hook_valid_payload():
+    result = openai_.request_hook(
         {"model": "test_model"},
         "test_function_fingerprint",
         generate_metadata=lambda: AIFunctionMetadata(
@@ -170,7 +228,7 @@ def test_request_serializer_valid_payload():
     assert result.ai_action == "completions"
 
 
-def test_response_serializer_valid_payload(mock_openai_object):
+def test_response_hook_valid_payload(mock_openai_object):
     prior_event = AIRequestStart(
         ai_model="test_model",
         ai_provider=openai_._OAI,
@@ -181,7 +239,7 @@ def test_response_serializer_valid_payload(mock_openai_object):
         _metadata=Metadata(function_fingerprint="test_function_fingerprint"),
     )
 
-    result = openai_.response_serializer(
+    result = openai_.response_hook(
         mock_openai_object,
         "test_function_fingerprint",
         prior_event,
@@ -195,7 +253,7 @@ def test_response_serializer_valid_payload(mock_openai_object):
     assert result.ai_action == "completions"
 
 
-def test_error_serializer_valid_error():
+def test_error_hook_valid_error():
     prior_event = AIRequestStart(
         ai_model="test_model",
         ai_provider=openai_._OAI,
@@ -207,7 +265,7 @@ def test_error_serializer_valid_error():
     )
 
     error = Exception("test exception")
-    result = openai_.error_serializer(
+    result = openai_.error_hook(
         error,
         "test_function_fingerprint",
         prior_event,

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -3,7 +3,12 @@ import pytest
 from rosnik import constants
 
 from rosnik.providers import openai as openai_
-from rosnik.types.ai import AIFunctionMetadata, AIRequestFinish, AIRequestStartStream, AIRequestStart
+from rosnik.types.ai import (
+    AIFunctionMetadata,
+    AIRequestFinish,
+    AIRequestStartStream,
+    AIRequestStart,
+)
 from rosnik.types.core import Metadata
 
 
@@ -68,7 +73,7 @@ def test_chat_completion__streaming(openai, event_queue):
     You are an aspiring edm artist. 
     Generate a song using words, for example "uhn tiss uhn tiss", that give the impression of an edm song.
     Your inspiration is the artist provided by the user.
-    """
+    """ # noqa
     input_text = "Daft Punk"
     openai_._patch_chat_completion(openai)
     assert event_queue.qsize() == 0
@@ -195,7 +200,7 @@ def test_chat_completion__streaming__azure(openai, event_queue):
     You are an aspiring edm artist. 
     Generate a song using words, for example "uhn tiss uhn tiss", that give the impression of an edm song.
     Your inspiration is the artist provided by the user.
-    """ #noqa
+    """  # noqa
     input_text = "Daft Punk"
     expected_api_base = "https://rosnik.openai.azure.com/"
     expected_api_type = "azure"


### PR DESCRIPTION
This PR adds support for the `stream=True` kwarg for OpenAI's SDK. 

The request/response/error serializer pattern changed to a "hook" pattern, where each function is responsible for translating the data to our event types _and_ sending the event to the queue. This simplifies `wrap` so that only hooks need to run around the wrapped function call.

Right now, there's a standard implementation of collecting content from the first choice in the stream. Unfortunately we can't get `usage` so that's lacking here.

We send 3 events on a stream:
1. `AIRequestStart` as usual
2. `AIRequestStartStream` which is useful for first byte latency tracking
3. `AIRequestFinish` which is fired after we see `finish_reason` while parsing SSEs