### PR TITLE
feat: add `event_context_hook` config

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -176,33 +176,29 @@ yaml = ["PyYAML"]
 
 [[package]]
 name = "black"
-version = "23.9.1"
+version = "23.10.0"
 description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "black-23.9.1-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:d6bc09188020c9ac2555a498949401ab35bb6bf76d4e0f8ee251694664df6301"},
-    {file = "black-23.9.1-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:13ef033794029b85dfea8032c9d3b92b42b526f1ff4bf13b2182ce4e917f5100"},
-    {file = "black-23.9.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:75a2dc41b183d4872d3a500d2b9c9016e67ed95738a3624f4751a0cb4818fe71"},
-    {file = "black-23.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13a2e4a93bb8ca74a749b6974925c27219bb3df4d42fc45e948a5d9feb5122b7"},
-    {file = "black-23.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:adc3e4442eef57f99b5590b245a328aad19c99552e0bdc7f0b04db6656debd80"},
-    {file = "black-23.9.1-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:8431445bf62d2a914b541da7ab3e2b4f3bc052d2ccbf157ebad18ea126efb91f"},
-    {file = "black-23.9.1-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:8fc1ddcf83f996247505db6b715294eba56ea9372e107fd54963c7553f2b6dfe"},
-    {file = "black-23.9.1-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:7d30ec46de88091e4316b17ae58bbbfc12b2de05e069030f6b747dfc649ad186"},
-    {file = "black-23.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031e8c69f3d3b09e1aa471a926a1eeb0b9071f80b17689a655f7885ac9325a6f"},
-    {file = "black-23.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:538efb451cd50f43aba394e9ec7ad55a37598faae3348d723b59ea8e91616300"},
-    {file = "black-23.9.1-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:638619a559280de0c2aa4d76f504891c9860bb8fa214267358f0a20f27c12948"},
-    {file = "black-23.9.1-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:a732b82747235e0542c03bf352c126052c0fbc458d8a239a94701175b17d4855"},
-    {file = "black-23.9.1-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:cf3a4d00e4cdb6734b64bf23cd4341421e8953615cba6b3670453737a72ec204"},
-    {file = "black-23.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf99f3de8b3273a8317681d8194ea222f10e0133a24a7548c73ce44ea1679377"},
-    {file = "black-23.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:14f04c990259576acd093871e7e9b14918eb28f1866f91968ff5524293f9c573"},
-    {file = "black-23.9.1-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:c619f063c2d68f19b2d7270f4cf3192cb81c9ec5bc5ba02df91471d0b88c4c5c"},
-    {file = "black-23.9.1-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:6a3b50e4b93f43b34a9d3ef00d9b6728b4a722c997c99ab09102fd5efdb88325"},
-    {file = "black-23.9.1-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:c46767e8df1b7beefb0899c4a95fb43058fa8500b6db144f4ff3ca38eb2f6393"},
-    {file = "black-23.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50254ebfa56aa46a9fdd5d651f9637485068a1adf42270148cd101cdf56e0ad9"},
-    {file = "black-23.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:403397c033adbc45c2bd41747da1f7fc7eaa44efbee256b53842470d4ac5a70f"},
-    {file = "black-23.9.1-py3-none-any.whl", hash = "sha256:6ccd59584cc834b6d127628713e4b6b968e5f79572da66284532525a042549f9"},
-    {file = "black-23.9.1.tar.gz", hash = "sha256:24b6b3ff5c6d9ea08a8888f6977eae858e1f340d7260cf56d70a49823236b62d"},
+    {file = "black-23.10.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:f8dc7d50d94063cdfd13c82368afd8588bac4ce360e4224ac399e769d6704e98"},
+    {file = "black-23.10.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:f20ff03f3fdd2fd4460b4f631663813e57dc277e37fb216463f3b907aa5a9bdd"},
+    {file = "black-23.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3d9129ce05b0829730323bdcb00f928a448a124af5acf90aa94d9aba6969604"},
+    {file = "black-23.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:960c21555be135c4b37b7018d63d6248bdae8514e5c55b71e994ad37407f45b8"},
+    {file = "black-23.10.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:30b78ac9b54cf87bcb9910ee3d499d2bc893afd52495066c49d9ee6b21eee06e"},
+    {file = "black-23.10.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:0e232f24a337fed7a82c1185ae46c56c4a6167fb0fe37411b43e876892c76699"},
+    {file = "black-23.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31946ec6f9c54ed7ba431c38bc81d758970dd734b96b8e8c2b17a367d7908171"},
+    {file = "black-23.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:c870bee76ad5f7a5ea7bd01dc646028d05568d33b0b09b7ecfc8ec0da3f3f39c"},
+    {file = "black-23.10.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:6901631b937acbee93c75537e74f69463adaf34379a04eef32425b88aca88a23"},
+    {file = "black-23.10.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:481167c60cd3e6b1cb8ef2aac0f76165843a374346aeeaa9d86765fe0dd0318b"},
+    {file = "black-23.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f74892b4b836e5162aa0452393112a574dac85e13902c57dfbaaf388e4eda37c"},
+    {file = "black-23.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:47c4510f70ec2e8f9135ba490811c071419c115e46f143e4dce2ac45afdcf4c9"},
+    {file = "black-23.10.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:76baba9281e5e5b230c9b7f83a96daf67a95e919c2dfc240d9e6295eab7b9204"},
+    {file = "black-23.10.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:a3c2ddb35f71976a4cfeca558848c2f2f89abc86b06e8dd89b5a65c1e6c0f22a"},
+    {file = "black-23.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db451a3363b1e765c172c3fd86213a4ce63fb8524c938ebd82919bf2a6e28c6a"},
+    {file = "black-23.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:7fb5fc36bb65160df21498d5a3dd330af8b6401be3f25af60c6ebfe23753f747"},
+    {file = "black-23.10.0-py3-none-any.whl", hash = "sha256:e223b731a0e025f8ef427dd79d8cd69c167da807f5710add30cdf131f13dd62e"},
+    {file = "black-23.10.0.tar.gz", hash = "sha256:31b9f87b277a68d0e99d2905edae08807c007973eaa609da5f0c62def6b7c0bd"},
 ]
 
 [package.dependencies]
@@ -869,20 +865,20 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.37"
+version = "3.1.38"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "GitPython-3.1.37-py3-none-any.whl", hash = "sha256:5f4c4187de49616d710a77e98ddf17b4782060a1788df441846bddefbb89ab33"},
-    {file = "GitPython-3.1.37.tar.gz", hash = "sha256:f9b9ddc0761c125d5780eab2d64be4873fc6817c2899cbcb34b02344bdc7bc54"},
+    {file = "GitPython-3.1.38-py3-none-any.whl", hash = "sha256:9e98b672ffcb081c2c8d5aa630d4251544fb040fb158863054242f24a2a2ba30"},
+    {file = "GitPython-3.1.38.tar.gz", hash = "sha256:4d683e8957c8998b58ddb937e3e6cd167215a180e1ffd4da769ab81c620a89fe"},
 ]
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
 
 [package.extras]
-test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mypy", "pre-commit", "pytest", "pytest-cov", "pytest-sugar"]
+test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest", "pytest-cov", "pytest-instafail", "pytest-subtests", "pytest-sugar"]
 
 [[package]]
 name = "idna"
@@ -2035,36 +2031,30 @@ python-versions = ">=3.6"
 files = [
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:d92f81886165cb14d7b067ef37e142256f1c6a90a65cd156b063a43da1708cfd"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl", hash = "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:b5edda50e5e9e15e54a6a8a0070302b00c518a9d32accc2346ad6c984aacd279"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl", hash = "sha256:53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl", hash = "sha256:c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:7048c338b6c86627afb27faecf418768acb6331fc24cfa56c93e8c9780f815fa"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"},
     {file = "ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3fcc54cb0c8b811ff66082de1680b4b14cf8a81dce0d4fbf665c2265a81e07a1"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win32.whl", hash = "sha256:75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:665f58bfd29b167039f714c6998178d27ccd83984084c286110ef26b230f259f"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win32.whl", hash = "sha256:955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl", hash = "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9eb5dee2772b0f704ca2e45b1713e4e5198c18f515b52743576d196348f374d3"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win32.whl", hash = "sha256:84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win_amd64.whl", hash = "sha256:25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15"},
@@ -2231,13 +2221,13 @@ telegram = ["requests"]
 
 [[package]]
 name = "trove-classifiers"
-version = "2023.9.19"
+version = "2023.10.17"
 description = "Canonical source for classifiers on PyPI (pypi.org)."
 optional = false
 python-versions = "*"
 files = [
-    {file = "trove-classifiers-2023.9.19.tar.gz", hash = "sha256:3e700af445c802f251ce2b741ee78d2e5dfa5ab8115b933b89ca631b414691c9"},
-    {file = "trove_classifiers-2023.9.19-py3-none-any.whl", hash = "sha256:55460364fe248294386d4dfa5d16544ec930493ecc6bd1db07a0d50afb37018e"},
+    {file = "trove-classifiers-2023.10.17.tar.gz", hash = "sha256:0ee4ec20b07a109ba6dd390b0336f9317ca8b58abcb51248c0ff72c641035f09"},
+    {file = "trove_classifiers-2023.10.17-py3-none-any.whl", hash = "sha256:37b89a6806b20b1c3411af705ce3b1f590360782f0dba99949cce94ae71f354b"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rosnik"
-version = "0.0.27"
+version = "0.0.28"
 description = "ROSNIK Python SDK"
 authors = ["Nick DiRienzo <nick@rosnik.ai>"]
 license = "MIT"

--- a/rosnik/client.py
+++ b/rosnik/client.py
@@ -15,10 +15,11 @@ except ImportError:
     pass
 
 
-def init(api_key=None, sync_mode=None, environment=None):
+def init(api_key=None, sync_mode=None, environment=None, event_context_hook=None):
     config.Config.api_key = api_key
     config.Config.sync_mode = sync_mode
     config.Config.environment = environment
+    config.Config.event_context_hook = event_context_hook
 
     if config.Config.api_key is None:
         warnings.warn("`api_key` is not set and an API token was not provided on init")

--- a/rosnik/config.py
+++ b/rosnik/config.py
@@ -9,11 +9,12 @@ ENVIRONMENT = f"{constants.NAMESPACE}_ENVIRONMENT"
 
 
 class _Config:
-    def __init__(self, api_key=None, sync_mode=None, environment=None):
+    def __init__(self, api_key=None, sync_mode=None, environment=None, event_context_hook=None):
         self._api_key = api_key or os.environ.get(API_KEY)
         _sync = sync_mode or os.environ.get(SYNC_MODE)
         self._sync_mode = _sync and _sync != "0"
         self._environment = environment or os.environ.get(ENVIRONMENT)
+        self._event_context_hook = event_context_hook
 
     @property
     def api_key(self):
@@ -44,6 +45,16 @@ class _Config:
         if self._environment is not None:
             return
         self._environment = value
+
+    @property
+    def event_context_hook(self):
+        return self._event_context_hook
+
+    @event_context_hook.setter
+    def event_context_hook(self, value):
+        if self._event_context_hook is not None:
+            return
+        self._event_context_hook = value
 
 
 Config = _Config()

--- a/rosnik/frameworks/flask_rosnik.py
+++ b/rosnik/frameworks/flask_rosnik.py
@@ -34,14 +34,15 @@ def _annotate_response_headers(response):
 
 
 class FlaskRosnik:
-    def __init__(self, app=None, api_key=None, sync_mode=None, environment=None):
+    def __init__(self, app=None, api_key=None, sync_mode=None, environment=None, event_context_hook=None):
         self.api_key = api_key
         self.sync_mode = sync_mode
         self.environment = environment
+        self.event_context_hook = event_context_hook
         if app is not None:
             self.init_app(app)
 
     def init_app(self, app):
         app.before_request(_before_request)
         app.after_request(_annotate_response_headers)
-        client.init(api_key=self.api_key, sync_mode=self.sync_mode, environment=self.environment)
+        client.init(api_key=self.api_key, sync_mode=self.sync_mode, environment=self.environment, event_context_hook=self.event_context_hook)

--- a/rosnik/types/core.py
+++ b/rosnik/types/core.py
@@ -24,7 +24,7 @@ class StaticMetadata:
     runtime: str = platform.python_implementation()
     runtime_version: str = platform.python_version()
     # TODO: how to sync pyproject version to this
-    sdk_version: str = "0.0.27"
+    sdk_version: str = "0.0.28"
 
 
 @dataclass(kw_only=True, slots=True)

--- a/rosnik/types/core.py
+++ b/rosnik/types/core.py
@@ -20,7 +20,7 @@ def _generate_event_id():
 
 @dataclass(kw_only=True, slots=True)
 class StaticMetadata:
-    environment: Optional[str] = config.Config.environment
+    environment: Optional[str] = field(default_factory=lambda: config.Config.environment)
     runtime: str = platform.python_implementation()
     runtime_version: str = platform.python_version()
     # TODO: how to sync pyproject version to this
@@ -65,9 +65,8 @@ class Event(DataClassJsonMixin):
             context_env = self.context.pop("environment", None)
             if context_env:
                 self._metadata.environment = context_env
-        except Exception as e:
-            # TODO: pull from function if possible
-            logger.exception("Could not generate context from fn")
+        except Exception:
+            logger.exception(f"Could not generate context from {config.Config.event_context_hook.__name__}")
 
 
 @dataclass(kw_only=True, slots=True)

--- a/tests/cassettes/test_ai_events/test_event_with_context.yaml
+++ b/tests/cassettes/test_ai_events/test_event_with_context.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You
+      are a helpful assistant."}, {"role": "user", "content": "What is a dog?"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-8AlI9M1QF5m7IzN57FNVy4WgEWnup\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1697575761,\n  \"model\": \"gpt-3.5-turbo-0613\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"A dog is a domesticated animal that
+        belongs to the Canidae family. It is often referred to as man's best friend
+        due to its close association with humans throughout history. Dogs come in
+        various breeds, sizes, and shapes, and have been bred for different purposes,
+        including companionship, working, and assisting humans, such as service dogs
+        and therapy dogs. They are known for their loyalty, intelligence, and ability
+        to form strong bonds with their human counterparts.\"\n      },\n      \"finish_reason\":
+        \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 22,\n    \"completion_tokens\":
+        93,\n    \"total_tokens\": 115\n  }\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 817b6858fe6e642c-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 17 Oct 2023 20:49:24 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0613
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '3256'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89971'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 19ms
+      x-request-id:
+      - c2f9d45875915cbe4c16d0bea5a0ae6c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_ai_events/test_event_with_context__streaming.yaml
+++ b/tests/cassettes/test_ai_events/test_event_with_context__streaming.yaml
@@ -1,0 +1,485 @@
+interactions:
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You
+      are a helpful assistant."}, {"role": "user", "content": "What is a dog?"}],
+      "stream": true}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"A"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        dog"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        is"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        a"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        domestic"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ated"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        mamm"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"al"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        commonly"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        kept"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        as"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        a"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        pet"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        or"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        working"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        animal"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"."},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        They"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        belong"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        to"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        the"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Can"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ida"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"e"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        family"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        and"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        are"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        known"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        for"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        their"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        loyalty"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        companions"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"hip"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        and"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        various"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        breeds"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"."},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Dogs"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        have"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        been"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        selectively"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        bred"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        for"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        different"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        purposes"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        such"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        as"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        hunting"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        her"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"ding"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        guarding"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        and"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        serving"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        as"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        therapy"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        animals"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"."},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        They"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        come"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        in"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        various"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        sizes"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        shapes"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        and"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        colors"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        with"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        a"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        range"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        of"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        temper"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"aments"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        and"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        characteristics"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"."},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        Dogs"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        are"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        known"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        for"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        their"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        strong"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        sense"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        of"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        smell"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        sharp"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        hearing"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":","},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        and"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        ability"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        to"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        form"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        close"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        bonds"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        with"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"
+        humans"},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"."},"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-8Albt9mCugyWs3w3aWifEON0mIa3X","object":"chat.completion.chunk","created":1697576985,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 817b863c5deacf09-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Tue, 17 Oct 2023 21:09:45 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0613
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '309'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89971'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 19ms
+      x-request-id:
+      - 79817d2626dfd888d9308b68d7dc3358
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_ai_events/test_event_with_error_doesnt_raise.yaml
+++ b/tests/cassettes/test_ai_events/test_event_with_error_doesnt_raise.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You
+      are a helpful assistant."}, {"role": "user", "content": "What is a dog?"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-8AlLaHmeQMm9R5rI8wEMDr7x5oUC3\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1697575974,\n  \"model\": \"gpt-3.5-turbo-0613\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"A dog is a domesticated mammal and
+        a popular pet. They belong to the species Canis lupus familiaris and are descendants
+        of wolves. Dogs are known for their companionship, loyalty, and ability to
+        be trained. They come in various breeds with different sizes, appearances,
+        and temperaments. Dogs are social animals and are often referred to as \\\"man's
+        best friend\\\" for their close relationship with humans.\"\n      },\n      \"finish_reason\":
+        \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 22,\n    \"completion_tokens\":
+        84,\n    \"total_tokens\": 106\n  }\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 817b6d8e5d7f172e-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 17 Oct 2023 20:52:57 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0613
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '2745'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89971'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 19ms
+      x-request-id:
+      - 5942c867c303be474676fc442a0d59bf
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_flask_rosnik/test_flask_with_context.yaml
+++ b/tests/cassettes/test_flask_rosnik/test_flask_with_context.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You
+      are a world class poet."}, {"role": "user", "content": "Write a poem about dogs."}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-8AlAc2yTm3aIbxQ8YlZYVUxIMzM5R\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1697575294,\n  \"model\": \"gpt-3.5-turbo-0613\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"In all their wondrous forms, so diverse,\\nOn
+        land they roam, in love they immerse.\\nWith hearts so pure, forever true,\\nOde
+        to the dogs, this verse I do.\\n\\nFrom snowy alps to desert sands,\\nTheir
+        loyal souls unite all lands.\\nWith eyes so kind, a comforting stare,\\nDogs
+        teach us love beyond compare.\\n\\nIn fields they frolic, tails held high,\\nGuiding
+        us through life's weary sky.\\nA paw to hold, when times are tough,\\nTheir
+        presence, oh, it's always enough.\\n\\nTheir furry embrace, a healing balm,\\nEasing
+        sorrows, bringing us calm.\\nWith wet-nosed kisses and playful nibbles,\\nDogs
+        fill our lives with endless giggles.\\n\\nThrough mountains climbed and rivers
+        crossed,\\nA dog, a friend, is never lost.\\nTheir paws engrave upon our hearts,\\nUnyielding
+        love that never departs.\\n\\nWhether big or small, their spirits immense,\\nDogs
+        teach us kindness, make no pretense.\\nA lesson of loyalty they bestow,\\nWith
+        every wagging tail's sweet hello.\\n\\nFrom golden retrievers with hearts
+        so gentle,\\nTo mighty shepherds, forever vigilant.\\nWith energy boundless
+        and dreams so wild,\\nDogs gift us joy, every wag and smile.\\n\\nThey guide
+        the blind and rescue those lost,\\nDefending our homes, no matter the cost.\\nIn
+        essence, dogs are our truest allies,\\nPatient listeners to our heartfelt
+        cries.\\n\\nSo let us cherish these canine souls,\\nWith gratitude, as the
+        tapestry unrolls.\\nFor dogs teach us, with love undeterred,\\nThat being
+        human is to love, absurd.\\n\\nIn their presence, we find solace and peace,\\nA
+        bond eternal, may it never cease.\\nOde to the dogs, in all their grace,\\nForever
+        in our hearts, their memory embrace.\"\n      },\n      \"finish_reason\":
+        \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 24,\n    \"completion_tokens\":
+        373,\n    \"total_tokens\": 397\n  }\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 817b5cf4fd22fa36-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 17 Oct 2023 20:41:45 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0613
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '10481'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89968'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 20ms
+      x-request-id:
+      - eaaf9aec036dcfb179d48a8de8efa59c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_ai_events.py
+++ b/tests/test_ai_events.py
@@ -1,6 +1,8 @@
 import platform
 import pytest
 
+import rosnik
+from rosnik import config
 from rosnik.providers import openai as openai_
 from rosnik.types.ai import AIRequestFinish, AIRequestStart
 
@@ -71,9 +73,77 @@ def test_chat_completion(openai, event_queue):
     assert finish_event.response_ms == (finish_event.sent_at - start_event.sent_at)
 
 
-def test_event_with_context():
+@pytest.mark.vcr
+def test_event_with_context(openai, event_queue):
     def _custom_hook():
         return {
             "environment": "testing",
-            
+            "test-key": "test-value",
+            "test-key2": "test-value2"
         }
+
+    rosnik.init(event_context_hook=_custom_hook)
+    # The default environment is not set
+    assert config.Config.environment is None
+    assert config.Config.event_context_hook is _custom_hook
+
+    system_prompt = "You are a helpful assistant."
+    input_text = "What is a dog?"
+    expected_messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": input_text},
+    ]
+    openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=expected_messages,
+    )
+
+    start_event: AIRequestStart = event_queue.get()
+    assert start_event._metadata.environment == "testing"
+    assert start_event.context == {"test-key": "test-value", "test-key2": "test-value2"}
+
+    finish_event: AIRequestFinish = event_queue.get()
+    assert finish_event._metadata.environment == "testing"
+    assert finish_event.context == {"test-key": "test-value", "test-key2": "test-value2"}
+
+
+@pytest.mark.vcr
+def test_event_with_error_doesnt_raise(openai, event_queue, caplog):
+    """Check that we don't raise exceptions if a user defined function
+        fails. And if there's a default environment, we should use it.
+    """
+    def _custom_hook():
+        raise Exception("oh no")
+
+    rosnik.init(event_context_hook=_custom_hook, environment="pytest")
+    assert config.Config.environment is "pytest"
+    assert config.Config.event_context_hook is _custom_hook
+
+    system_prompt = "You are a helpful assistant."
+    input_text = "What is a dog?"
+    expected_messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": input_text},
+    ]
+    openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=expected_messages,
+    )
+
+    start_event: AIRequestStart = event_queue.get()
+    # pytest because context didn't set anything
+    assert start_event._metadata.environment == "pytest"
+    # None because context hook exploded
+    assert start_event.context == None
+
+    finish_event: AIRequestFinish = event_queue.get()
+    assert finish_event._metadata.environment == "pytest"
+    # None because context hook exploded
+    assert finish_event.context == None
+
+    assert len(caplog.records) == 2
+    for record in caplog.records:
+        assert str(record.exc_info[1]) == "oh no"
+        assert 'Could not generate context from _custom_hook' == record.message
+
+    

--- a/tests/test_ai_events.py
+++ b/tests/test_ai_events.py
@@ -69,3 +69,11 @@ def test_chat_completion(openai, event_queue):
     assert start_event.ai_metadata.openai_attributes.api_type == "open_ai"
     assert start_event.ai_metadata.openai_attributes.api_version is None
     assert finish_event.response_ms == (finish_event.sent_at - start_event.sent_at)
+
+
+def test_event_with_context():
+    def _custom_hook():
+        return {
+            "environment": "testing",
+            
+        }

--- a/tests/test_ai_events.py
+++ b/tests/test_ai_events.py
@@ -20,7 +20,7 @@ def validate_common_attributes(event: Event):
     assert event._metadata.environment is None
     assert event._metadata.runtime == platform.python_implementation()
     assert event._metadata.runtime_version == platform.python_version()
-    assert event._metadata.sdk_version == "0.0.27"
+    assert event._metadata.sdk_version == "0.0.28"
     assert event._metadata.function_fingerprint
     assert len(event._metadata.function_fingerprint.split(".")) == 5
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -54,3 +54,13 @@ def test_openai_enabled_and_sync_mode(caplog, mocker):
     messages = [record.message for record in caplog.records]
     "OpenAI is enabled. Patching." in messages
     "Running in sync mode" in messages
+
+def test_client_init__with_params():
+    def _custom_hook():
+        return {}
+
+    rosnik.init(api_key="test_key", sync_mode=True, environment="development", event_context_hook=_custom_hook)
+    assert rosnik.config.Config.api_key == "test_key"
+    assert rosnik.config.Config.sync_mode is True
+    assert rosnik.config.Config.environment == "development"
+    assert rosnik.config.Config.event_context_hook is _custom_hook

--- a/tests/test_flask_rosnik.py
+++ b/tests/test_flask_rosnik.py
@@ -1,10 +1,11 @@
 import pytest
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 import ulid
 
 from rosnik import config
 from rosnik import flask_rosnik, headers, state
 from rosnik.events import queue
+from rosnik.types.ai import AIRequestFinish, AIRequestStart
 
 
 # Initialize your extension
@@ -30,6 +31,35 @@ def app(mocker):
     yield app
     state._reset()
 
+
+@pytest.fixture
+def app_with_event_context_hook(mocker):
+    mocker.patch("rosnik.events.queue.EventProcessor")
+    app = Flask(__name__)
+
+    def _request_context():
+        host = request.headers.get("host")
+        return {
+            "environment": "testing",
+            "host": host
+        }
+
+    @app.get("/")
+    def index():
+        import openai
+
+        openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You are a world class poet."},
+                {"role": "user", "content": "Write a poem about dogs."},
+            ],
+        )
+        return jsonify({"success": True})
+
+    flask_rosnik.FlaskRosnik(app, event_context_hook=_request_context)
+    yield app
+    state._reset()
 
 # Test case for returned headers
 @pytest.mark.vcr
@@ -122,16 +152,51 @@ def test_no_headers(app):
         assert queue.event_queue.qsize() == 0
 
 
-@pytest.mark.vcr
 def test_client_init(mocker, app):
     patch_init = mocker.patch("rosnik.client.init")  # Mock the client initialization
     flask_rosnik.FlaskRosnik(app)
     patch_init.assert_called_once()
 
 
-@pytest.mark.vcr
-def test_client_init__with_params(app):
-    flask_rosnik.FlaskRosnik(app, api_key="test_key", sync_mode=True, environment="development")
+def test_client_init__with_params():
+    def _custom_hook():
+        return {}
+
+    test_app = Flask(__name__)
+    ext = flask_rosnik.FlaskRosnik(test_app, api_key="test_key", sync_mode=True, environment="development", event_context_hook=_custom_hook)
+    ext.init_app(test_app)
     assert config.Config.api_key == "test_key"
     assert config.Config.sync_mode is True
     assert config.Config.environment == "development"
+    assert config.Config.event_context_hook is _custom_hook
+
+@pytest.mark.vcr
+def test_flask_with_context(app_with_event_context_hook, event_queue):
+    with app_with_event_context_hook.test_client() as client:
+        res = client.get(
+            "/",
+            headers={
+                headers.JOURNEY_ID_KEY: "test-journey",
+                headers.DEVICE_ID_KEY: "test-device",
+                headers.INTERACTION_ID_KEY: "test-user-interaction",
+            },
+        )
+        assert headers.JOURNEY_ID_KEY in res.headers
+        assert res.headers.get(headers.JOURNEY_ID_KEY) == "test-journey"
+        assert event_queue.qsize() == 2
+        
+        start_event: AIRequestStart = event_queue.get()
+        assert start_event.journey_id == "test-journey"
+        assert start_event.device_id == "test-device"
+        assert start_event.user_interaction_id == "test-user-interaction"
+        assert start_event._metadata.environment == "testing"
+        assert start_event.context == {"host": "localhost"}
+        
+        finish_event: AIRequestFinish = event_queue.get()
+        assert finish_event.journey_id == "test-journey"
+        assert finish_event.device_id == "test-device"
+        assert finish_event.user_interaction_id == "test-user-interaction"
+        assert finish_event._metadata.environment == "testing"
+        assert finish_event.context == {"host": "localhost"}
+        
+        assert event_queue.qsize() == 0


### PR DESCRIPTION
This PR introduces the ability to annotate events with user-defined context. If a reserved word is used, e.g. `environment` then we will overwrite our metadata with that and remove it from context. This way `context` is only user-defined values.

If the hook raises an exception, we log that via `logger.exception` and do not update event data. However, we will continue to send the event along.

To use this, you can pass `event_context_hook` in `init` or in the `FlaskRosnik` constructor. For example:

```
def _my_custom_context():
  return {
    "environment": "staging",
    "origin": request.headers.get("Origin")
  }

rosnik.init(event_context_hook=_my_custom_context)
```