### PR TITLE
fix: sent_at caching and ai_request_start_event_id setting 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -780,6 +780,20 @@ async = ["asgiref (>=3.2)"]
 dotenv = ["python-dotenv"]
 
 [[package]]
+name = "freezegun"
+version = "1.2.2"
+description = "Let your Python tests travel through time"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "freezegun-1.2.2-py3-none-any.whl", hash = "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f"},
+    {file = "freezegun-1.2.2.tar.gz", hash = "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "frozenlist"
 version = "1.4.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -1692,6 +1706,21 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-freezegun"
+version = "0.4.2"
+description = "Wrap tests with fixtures in freeze_time"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytest-freezegun-0.4.2.zip", hash = "sha256:19c82d5633751bf3ec92caa481fb5cffaac1787bd485f0df6436fd6242176949"},
+    {file = "pytest_freezegun-0.4.2-py2.py3-none-any.whl", hash = "sha256:5318a6bfb8ba4b709c8471c94d0033113877b3ee02da5bfcd917c1889cde99a7"},
+]
+
+[package.dependencies]
+freezegun = ">0.3"
+pytest = ">=3.0.0"
+
+[[package]]
 name = "pytest-mock"
 version = "3.11.1"
 description = "Thin-wrapper around the mock package for easier use with pytest"
@@ -1726,6 +1755,20 @@ vcrpy = ">=2.0.1"
 [package.extras]
 dev = ["pytest-recording[tests]"]
 tests = ["pytest-httpbin", "pytest-mock", "requests", "werkzeug (==2.3.6)"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
@@ -2150,6 +2193,17 @@ python-versions = ">=3.7"
 files = [
     {file = "shellingham-1.5.3-py2.py3-none-any.whl", hash = "sha256:419c6a164770c9c7cfcaeddfacb3d31ac7a8db0b0f3e9c1287679359734107e9"},
     {file = "shellingham-1.5.3.tar.gz", hash = "sha256:cb4a6fec583535bc6da17b647dd2330cf7ef30239e05d547d99ae3705fd0f7f8"},
+]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 
 [[package]]
@@ -2625,4 +2679,4 @@ openai = ["openai"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "b52e27e6c614cd2a7852a82df2fb8b3ccdedd57deb8d56b17f943913d0bc0a40"
+content-hash = "f2f24c383557d871d9c24560301dc7c85ca7e24f7896672d4a2158b14e5c3f24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pytest-cov = "^4.1.0"
 pytest-mock = "^3.11.1"
 pytest-recording = "^0.13.0"
 responses = "^0.23.3"
+pytest-freezegun = "^0.4.2"
 
 [tool.poetry.extras]
 openai = ["openai"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rosnik"
-version = "0.0.29"
+version = "0.0.30"
 description = "ROSNIK Python SDK"
 authors = ["Nick DiRienzo <nick@rosnik.ai>"]
 license = "MIT"

--- a/rosnik/types/ai.py
+++ b/rosnik/types/ai.py
@@ -51,6 +51,11 @@ class AIRequestStart(AIEvent):
     # JSONable request payload / kwargs sent through the SDK
     request_payload: dict
     ai_metadata: AIFunctionMetadata
+    ai_request_start_event_id: Optional[str] = None
+
+    def __post_init__(self):
+        AIEvent.__post_init__(self)
+        self.ai_request_start_event_id = self.event_id
 
 
 @dataclass(kw_only=True, slots=True)

--- a/rosnik/types/core.py
+++ b/rosnik/types/core.py
@@ -23,7 +23,7 @@ class StaticMetadata:
     runtime: str = platform.python_implementation()
     runtime_version: str = platform.python_version()
     # TODO: how to sync pyproject version to this
-    sdk_version: str = "0.0.29"
+    sdk_version: str = "0.0.30"
 
 
 @dataclass(kw_only=True, slots=True)

--- a/rosnik/types/core.py
+++ b/rosnik/types/core.py
@@ -42,7 +42,7 @@ class Event(DataClassJsonMixin):
     event_type: str
     journey_id: str = field(default_factory=state.get_journey_id)
     # Epoch in ms
-    sent_at: int = int(time.time_ns() / 1000000)
+    sent_at: int = field(default_factory=lambda: int(time.time_ns() / 1000000))
     # Epoch unless not set, which will be -1
     occurred_at: Optional[int] = None
     # JSONable user defined context

--- a/tests/test_ai_events.py
+++ b/tests/test_ai_events.py
@@ -21,7 +21,7 @@ def validate_common_attributes(event: Event):
     assert event._metadata.environment is None
     assert event._metadata.runtime == platform.python_implementation()
     assert event._metadata.runtime_version == platform.python_version()
-    assert event._metadata.sdk_version == "0.0.29"
+    assert event._metadata.sdk_version == "0.0.30"
     assert event._metadata.function_fingerprint
     assert len(event._metadata.function_fingerprint.split(".")) == 5
 

--- a/tests/test_ai_events.py
+++ b/tests/test_ai_events.py
@@ -1,3 +1,4 @@
+import time
 import platform
 import pytest
 
@@ -14,7 +15,7 @@ from rosnik.types.core import Event
 def validate_common_attributes(event: Event):
     assert isinstance(ulid.parse(event.event_id), ulid.ULID)
     assert isinstance(ulid.parse(event.journey_id), ulid.ULID)
-    assert event.sent_at
+    assert event.sent_at == (int(time.time_ns() / 1000000))
     assert event.device_id is None
     assert event._metadata
     assert event._metadata.environment is None
@@ -26,7 +27,7 @@ def validate_common_attributes(event: Event):
 
 
 @pytest.mark.vcr
-def test_chat_completion(openai, event_queue):
+def test_chat_completion(openai, event_queue, freezer):
     system_prompt = "You are a helpful assistant."
     input_text = "What is a dog?"
     openai_._patch_chat_completion(openai)
@@ -57,6 +58,7 @@ def test_chat_completion(openai, event_queue):
     assert start_event.ai_metadata.openai_attributes.api_base == "https://api.openai.com/v1"
     assert start_event.ai_metadata.openai_attributes.api_type == "open_ai"
     assert start_event.ai_metadata.openai_attributes.api_version is None
+    assert start_event.ai_request_start_event_id == start_event.event_id
 
     assert isinstance(finish_event, AIRequestFinish)
     validate_common_attributes(finish_event)


### PR DESCRIPTION
We were caching `sent_at` at the start of the dataclass but it needs to be in a `default_factory` lambda, otherwise we'll have the same `sent_at` value for each `ai.request.start` event.