### PR TITLE
feat: add `rosnik.context` context manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rosnik"
-version = "0.0.34"
+version = "0.0.35"
 description = "ROSNIK Python SDK"
 authors = ["Nick DiRienzo <nick@rosnik.ai>"]
 license = "MIT"

--- a/rosnik/__init__.py
+++ b/rosnik/__init__.py
@@ -1,5 +1,12 @@
-from .client import init
+from .client import init, context
 from .frameworks import flask_rosnik, django
 from .events.user import track_user_feedback, track_user_interaction
 
-__all__ = ["init", "flask_rosnik", "track_user_interaction", "track_user_feedback", "django"]
+__all__ = [
+    "init",
+    "flask_rosnik",
+    "track_user_interaction",
+    "track_user_feedback",
+    "django",
+    "context",
+]

--- a/rosnik/client.py
+++ b/rosnik/client.py
@@ -1,7 +1,8 @@
 import logging
 import warnings
+from contextlib import contextmanager
 
-from rosnik import config
+from rosnik import config, state
 
 logger = logging.getLogger(__name__)
 
@@ -32,3 +33,11 @@ def init(api_key=None, sync_mode=None, environment=None, event_context_hook=None
 
     if config.Config.sync_mode:
         logger.debug("Running in sync mode")
+
+
+@contextmanager
+def context(prompt_label: str = None, **kwargs):
+    """Set context for the events sent within this context manager."""
+    token = state.store(state.State.CONTEXT_ID, {"prompt_label": prompt_label, **kwargs})
+    yield
+    state.reset_context(token)

--- a/rosnik/frameworks/django.py
+++ b/rosnik/frameworks/django.py
@@ -5,9 +5,11 @@ try:
 except ImportError:
     settings = None
 
+
 def _to_django_header(key):
     """Converts our header key to a Django header key."""
     return f'HTTP_{key.replace("-", "_").upper()}'
+
 
 def rosnik_middleware(get_response):
     # Initialize our SDK at the start using Django settings.

--- a/rosnik/state.py
+++ b/rosnik/state.py
@@ -5,7 +5,13 @@ if there is not an external journey ID supplied.
 We manage state here across the 3 values we care about.
 Outside of Journey ID, they can be set to None, which
 would mean they are user-less journeys.
+
+We also manage context here, which is a user-defined
+JSONable dictionary of key-value pairs that get
+collected and sent with every event. See `rosnik.context`
+for the context manager and details on how to use it.
 """
+import contextvars
 from enum import Enum
 import logging
 from contextvars import ContextVar
@@ -18,27 +24,31 @@ logger = logging.getLogger(__name__)
 _journey_id_key = "journey_id"
 _user_interaction_id_key = "user_interaction_id"
 _device_id_key = "device_id"
+_context_key = "context"
 
 journey_id_cv: ContextVar[Optional[str]] = ContextVar(_journey_id_key)
 user_interaction_id_cv: ContextVar[Optional[str]] = ContextVar(_user_interaction_id_key)
 device_id_cv: ContextVar[Optional[str]] = ContextVar(_device_id_key)
+context_cv: ContextVar[Optional[dict[str, str]]] = ContextVar(_context_key)
 
 
 class State(Enum):
     JOURNEY_ID = _journey_id_key
     USER_INTERACTION_ID = _user_interaction_id_key
     DEVICE_ID = _device_id_key
+    CONTEXT_ID = _context_key
 
 
 _state = {
     State.JOURNEY_ID: journey_id_cv,
     State.USER_INTERACTION_ID: user_interaction_id_cv,
     State.DEVICE_ID: device_id_cv,
+    State.CONTEXT_ID: context_cv,
 }
 
 
 def store(state_type: State, value: str):
-    _state[state_type].set(value)
+    return _state[state_type].set(value)
 
 
 def retrieve(state_type: State):
@@ -66,7 +76,16 @@ def get_user_interaction_id():
     return retrieve(State.USER_INTERACTION_ID)
 
 
+def get_context():
+    return retrieve(State.CONTEXT_ID) or {}
+
+
+def reset_context(token: contextvars.Token):
+    return context_cv.reset(token)
+
+
 def _reset():
     journey_id_cv.set(None)
     user_interaction_id_cv.set(None)
     device_id_cv.set(None)
+    context_cv.set(None)

--- a/rosnik/types/core.py
+++ b/rosnik/types/core.py
@@ -23,7 +23,7 @@ class StaticMetadata:
     runtime: str = platform.python_implementation()
     runtime_version: str = platform.python_version()
     # TODO: how to sync pyproject version to this
-    sdk_version: str = "0.0.34"
+    sdk_version: str = "0.0.35"
 
 
 @dataclass(kw_only=True, slots=True)
@@ -58,14 +58,32 @@ class Event(DataClassJsonMixin):
     user_interaction_id: Optional[str] = field(default_factory=state.get_user_interaction_id)
 
     def __post_init__(self):
-        if not isinstance(config.Config.event_context_hook, Callable):
+        """We have two different contexts:
+        1. Hook-level context which request-level / global
+        2. Event-level context which is per-event / via a context manager
+        Here we merge them together.
+        """
+        stored_context = state.get_context()
+
+        # If both contexts are empty, we don't need to do anything.
+        if not isinstance(config.Config.event_context_hook, Callable) and not stored_context:
             return
 
+        # Make this a callable so we can call it later if needed.
+        event_hook = config.Config.event_context_hook
+        if not isinstance(event_hook, Callable):
+            def event_hook():
+                return {}
+
         try:
-            self.context = config.Config.event_context_hook()
-            context_env = self.context.pop("environment", None)
+            global_context = event_hook()
+            context_env = global_context.pop("environment", None)
             if context_env:
                 self._metadata.environment = context_env
+
+            # Merge everything together with this event's specific context taking precedence,
+            # then the stored context, then the global context.
+            self.context = {**global_context, **stored_context, **(self.context or {})}
         except Exception:
             logger.exception(
                 f"Could not generate context from {config.Config.event_context_hook.__name__}"

--- a/tests/cassettes/test_ai_events/test_event_with_context_manager.yaml
+++ b/tests/cassettes/test_ai_events/test_event_with_context_manager.yaml
@@ -1,0 +1,261 @@
+interactions:
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You
+      are a helpful assistant."}, {"role": "user", "content": "What is a dog?"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-8GEjJqJa9i3PdUtRx0Dis0N1t1I2z\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1698880561,\n  \"model\": \"gpt-3.5-turbo-0613\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"A dog is a domesticated mammal that
+        belongs to the Canidae family. They are known for their loyalty, intelligence,
+        and social nature. Dogs come in various shapes, sizes, and breeds, each with
+        its own unique characteristics and traits. They are often kept as pets and
+        provide companionship, security, and assistance in various activities such
+        as hunting, herding, and search and rescue operations.\"\n      },\n      \"finish_reason\":
+        \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 22,\n    \"completion_tokens\":
+        81,\n    \"total_tokens\": 103\n  }\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 81f7d7d29f0e1586-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 01 Nov 2023 23:16:02 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0613
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '1260'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89971'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 19ms
+      x-request-id:
+      - f02b4ef26d0ceb0addd42c9cc8acff17
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You
+      are a helpful assistant."}, {"role": "user", "content": "What is a dog?"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-8GEjLeoL3dbSL6qdzAJGMIrMEPpSU\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1698880563,\n  \"model\": \"gpt-3.5-turbo-0613\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"A dog is a domesticated mammal that
+        belongs to the Canidae family. They are known for their loyalty and strong
+        bond with humans. Dogs come in various breeds, sizes, and colors, and are
+        often kept as pets or working animals. They are social animals, highly adaptable,
+        and have been domesticated for thousands of years. Dogs are also known for
+        their intelligence and ability to learn commands and perform tasks.\"\n      },\n
+        \     \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
+        22,\n    \"completion_tokens\": 84,\n    \"total_tokens\": 106\n  }\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 81f7d7db6820159e-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 01 Nov 2023 23:16:05 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0613
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '2283'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89970'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 19ms
+      x-request-id:
+      - cc2ccb199c277e4e8c474cc075b2a73b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You
+      are a helpful assistant."}, {"role": "user", "content": "What is a dog?"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-8GEjNAfUIhEKPQ37s9cStMoj6hPg7\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1698880565,\n  \"model\": \"gpt-3.5-turbo-0613\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"A dog is a domesticated mammal that
+        belongs to the Canidae family, which also includes foxes, wolves, and other
+        species. Dogs are known for their loyalty, intelligence, and ability to form
+        strong bonds with humans. They come in various breeds, which differ in size,
+        appearance, and temperament. Dogs are commonly kept as pets and are often
+        trained to perform various tasks such as herding, hunting, search and rescue,
+        and therapy work.\"\n      },\n      \"finish_reason\": \"stop\"\n    }\n
+        \ ],\n  \"usage\": {\n    \"prompt_tokens\": 22,\n    \"completion_tokens\":
+        92,\n    \"total_tokens\": 114\n  }\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 81f7d7ec0cdfceb1-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 01 Nov 2023 23:16:07 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0613
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '1773'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89971'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 19ms
+      x-request-id:
+      - d6cb37f779241745e883d9a26279d9b6
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_ai_events/test_event_with_context_manager__stacked.yaml
+++ b/tests/cassettes/test_ai_events/test_event_with_context_manager__stacked.yaml
@@ -1,0 +1,347 @@
+interactions:
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You
+      are a helpful assistant."}, {"role": "user", "content": "What is a dog?"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-8GEnKyyz2Tycf6sHsZB1aKCxtifFk\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1698880810,\n  \"model\": \"gpt-3.5-turbo-0613\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"A dog is a domesticated mammal of the
+        Canidae family, commonly kept as a pet or used for various purposes such as
+        hunting, herding, guarding, or assisting people with disabilities. They are
+        known for their loyalty, companionship, and variety of breeds with different
+        sizes, appearances, and temperaments.\"\n      },\n      \"finish_reason\":
+        \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 22,\n    \"completion_tokens\":
+        64,\n    \"total_tokens\": 86\n  }\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 81f7dde89c8b9685-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 01 Nov 2023 23:20:11 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0613
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '1442'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89971'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 19ms
+      x-request-id:
+      - c7ef27443d8c469f3e73d6292a96c006
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You
+      are a helpful assistant."}, {"role": "user", "content": "What is a dog?"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-8GEnNOIjItrklm7xPMUXGxL8cNwiM\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1698880813,\n  \"model\": \"gpt-3.5-turbo-0613\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"A dog is a domesticated animal that
+        belongs to the Canidae family, which also includes wolves, foxes, and other
+        animals. They are known for their loyalty, companionship, and diverse breeds.
+        Dogs are popular pets and are often trained to perform tasks such as guarding,
+        herding, and assisting people with various needs. They come in different shapes,
+        sizes, and colors, and have a well-developed sense of smell, hearing, and
+        vision.\"\n      },\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\":
+        {\n    \"prompt_tokens\": 22,\n    \"completion_tokens\": 93,\n    \"total_tokens\":
+        115\n  }\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 81f7ddf29bb8176b-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 01 Nov 2023 23:20:14 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0613
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '1850'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89970'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 19ms
+      x-request-id:
+      - 251fc270ef402649ab3845c6d1bb345d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You
+      are a helpful assistant."}, {"role": "user", "content": "What is a dog?"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-8GEnPmmDAdLAhB1h7ONaZE8IvMEyh\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1698880815,\n  \"model\": \"gpt-3.5-turbo-0613\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"A dog is a domesticated mammal that
+        belongs to the Canidae family. They are known for their loyalty, companionship,
+        and their ability to be trained for various purposes such as hunting, herding,
+        and assisting people with disabilities. Dogs come in various shapes, sizes,
+        and breeds, each with its own unique characteristics and temperaments. They
+        are often kept as pets and are known for their strong bond with humans.\"\n
+        \     },\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n
+        \   \"prompt_tokens\": 22,\n    \"completion_tokens\": 86,\n    \"total_tokens\":
+        108\n  }\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 81f7de05dcf096ad-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 01 Nov 2023 23:20:17 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0613
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '2338'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89970'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 19ms
+      x-request-id:
+      - ff70bf6e58ccc7df8dcbb53d655c52d9
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You
+      are a helpful assistant."}, {"role": "user", "content": "What is a dog?"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.10
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.10", "httplib": "requests", "lang": "python",
+        "lang_version": "3.10.11", "platform": "macOS-14.0-x86_64-i386-64bit", "publisher":
+        "openai", "uname": "Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15
+        14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 i386"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-8GEnSJKtOnqyFkPo9z4yt8yhm7IP0\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1698880818,\n  \"model\": \"gpt-3.5-turbo-0613\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"A dog is a domesticated mammal belonging
+        to the Canidae family. They are commonly kept as pets and are known for their
+        loyalty, companionship, and ability to be trained. Dogs come in various breeds,
+        shapes, and sizes, and have been bred for different purposes such as working
+        dogs, hunting dogs, and companion dogs. They are known for their strong sense
+        of smell, hearing, and their ability to form deep bonds with humans.\"\n      },\n
+        \     \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
+        22,\n    \"completion_tokens\": 90,\n    \"total_tokens\": 112\n  }\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 81f7de156e64689a-SJC
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 01 Nov 2023 23:20:19 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0613
+      openai-organization:
+      - user-owo4fzpozfbbclosr06eubzj
+      openai-processing-ms:
+      - '2131'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89971'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 19ms
+      x-request-id:
+      - c0266b6ca08582cb0311d517ded29023
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,13 +4,15 @@ from rosnik import config
 from rosnik import state
 from rosnik.types import core
 
+
 # Setup the fixture for Event data
 @pytest.fixture
-def event_data(mocker):
+def event_data():
     return {
         "event_type": "test_event",
-        "_metadata": mocker.MagicMock()
+        "_metadata": core.Metadata(function_fingerprint="test_fingerprint"),
     }
+
 
 # Fixture to reset the context after each test to avoid side effects
 @pytest.fixture(autouse=True)
@@ -19,117 +21,236 @@ def reset_state():
     yield
     state._reset()
 
+
 def test_post_init_without_contexts(event_data):
     # Assuming no context is set, no global context should be added.
     event = core.Event(**event_data)
     assert event.context is None
 
+
 def test_post_init_with_context(event_data):
     # Set a context value using the state management functions
-    context = {'key': 'value'}
+    context = {"key": "value"}
     state.store(state.State.CONTEXT_ID, context)
-    
+
     event = core.Event(**event_data)
     assert event.context == context
 
+
 def test_event_context_overrides_stored_and_global(event_data):
     # Set a stored context and a global context hook
-    stored_context = {'shared': 'stored', 'unique_stored': 'value_stored'}
-    global_context = {'shared': 'global', 'unique_global': 'value_global'}
-    event_context = {'shared': 'event', 'unique_event': 'value_event'}
-    
+    stored_context = {"shared": "stored", "unique_stored": "value_stored"}
+    global_context = {"shared": "global", "unique_global": "value_global"}
+    event_context = {"shared": "event", "unique_event": "value_event"}
+
     # Simulate setting stored context
     state.store(state.State.CONTEXT_ID, stored_context)
-    
+
     # Simulate a global context hook
     config.Config.event_context_hook = lambda: global_context
-    
+
     # Now create an Event with an event-specific context
     event = core.Event(**event_data, context=event_context)
-    
+
     # The event's context should have 'event' as the 'shared' value
-    expected_context = {'shared': 'event', 'unique_global': 'value_global', 'unique_stored': 'value_stored', 'unique_event': 'value_event'}
+    expected_context = {
+        "shared": "event",
+        "unique_global": "value_global",
+        "unique_stored": "value_stored",
+        "unique_event": "value_event",
+    }
     assert event.context == expected_context
+
 
 def test_stored_context_overrides_global(event_data):
     # Set a stored context and a global context hook
-    stored_context = {'shared': 'stored', 'unique_stored': 'value_stored'}
-    global_context = {'shared': 'global', 'unique_global': 'value_global'}
-    
+    stored_context = {"shared": "stored", "unique_stored": "value_stored"}
+    global_context = {"shared": "global", "unique_global": "value_global"}
+
     # Simulate setting stored context
     state.store(state.State.CONTEXT_ID, stored_context)
-    
+
     # Simulate a global context hook
     config.Config.event_context_hook = lambda: global_context
-    
+
     # Now create an Event without an event-specific context
     event = core.Event(**event_data)
-    
+
     # The event's context should have 'stored' as the 'shared' value
-    expected_context = {'shared': 'stored', 'unique_global': 'value_global', 'unique_stored': 'value_stored'}
+    expected_context = {
+        "shared": "stored",
+        "unique_global": "value_global",
+        "unique_stored": "value_stored",
+    }
     assert event.context == expected_context
+
 
 def test_global_context_applied_when_no_other(event_data):
     # Set a global context hook only
-    global_context = {'shared': 'global', 'unique_global': 'value_global'}
-    
+    global_context = {"shared": "global", "unique_global": "value_global"}
+
     # Simulate a global context hook
     config.Config.event_context_hook = lambda: global_context
-    
+
     # Now create an Event without an event-specific or stored context
     event = core.Event(**event_data)
-    
+
     # The event's context should be just the global context
     assert event.context == global_context
+
 
 def test_no_contexts_results_in_none(event_data):
     # Assuming no contexts are set anywhere
     # Simulate a global context hook that returns None
     config.Config.event_context_hook = lambda: None
-    
+
     # Now create an Event without any context
     event = core.Event(**event_data)
-    
+
     # The event's context should be None
     assert event.context is None
+
 
 def test_post_init_with_journey_id(event_data):
     # Set a journey ID using the state management functions
     journey_id = state.create_journey_id()
-    
+
     event = core.Event(**event_data)
     assert event.journey_id == journey_id
+
 
 def test_post_init_with_user_interaction_id(event_data):
     # Set a user interaction ID using the state management functions
     user_interaction_id = "interaction_123"
     state.store(state.State.USER_INTERACTION_ID, user_interaction_id)
-    
+
     event = core.Event(**event_data)
     assert event.user_interaction_id == user_interaction_id
+
 
 def test_post_init_with_device_id(event_data):
     # Set a device ID using the state management functions
     device_id = "device_123"
     state.store(state.State.DEVICE_ID, device_id)
-    
+
     event = core.Event(**event_data)
     assert event.device_id == device_id
 
+
 def test_post_init_with_all_states(event_data):
     # Set up all states using the state management functions
-    context = {'key': 'value'}
+    context = {"key": "value"}
     journey_id = state.create_journey_id()
     user_interaction_id = "interaction_123"
     device_id = "device_123"
-    
+
     state.store(state.State.CONTEXT_ID, context)
     state.store(state.State.USER_INTERACTION_ID, user_interaction_id)
     state.store(state.State.DEVICE_ID, device_id)
-    
+
     event = core.Event(**event_data)
     # The event's context should contain the context set up above
     assert event.context == context
     assert event.journey_id == journey_id
     assert event.user_interaction_id == user_interaction_id
     assert event.device_id == device_id
+
+
+def test_event_environment_overrides_stored_and_global(event_data):
+    # Set a stored context and a global context hook with environment values
+    stored_context = {"environment": "stored_env"}
+    global_context = {"environment": "global_env", "other": "value"}
+    event_context = {"environment": "event_env", "specific": "data"}
+
+    # Simulate setting stored context
+    state.store(state.State.CONTEXT_ID, stored_context)
+
+    # Simulate a global context hook
+    config.Config.event_context_hook = lambda: global_context
+
+    # Now create an Event with an event-specific context including an environment
+    event = core.Event(**event_data, context=event_context)
+
+    # The environment should be taken from the event context
+    assert event._metadata.environment == "event_env"
+    # The rest of the context should have 'event' as the 'shared' value
+    assert event.context == {"other": "value", "specific": "data"}
+
+
+def test_stored_environment_overrides_global(event_data):
+    # Set a stored context and a global context hook with environment values
+    stored_context = {"environment": "stored_env"}
+    global_context = {"environment": "global_env", "other": "value"}
+
+    # Simulate setting stored context
+    state.store(state.State.CONTEXT_ID, stored_context)
+
+    # Simulate a global context hook
+    config.Config.event_context_hook = lambda: global_context
+
+    # Now create an Event without an event-specific environment
+    event = core.Event(**event_data)
+
+    # The environment should be taken from the stored context
+    assert event._metadata.environment == "stored_env"
+    assert event.context == {"other": "value"}
+
+
+def test_global_environment_applied_when_no_other(event_data):
+    # Set a global context hook with an environment value
+    global_context = {"environment": "global_env", "other": "value"}
+
+    # Simulate a global context hook
+    config.Config.event_context_hook = lambda: global_context
+
+    # Now create an Event without an event-specific or stored environment
+    event = core.Event(**event_data)
+
+    # The environment should be taken from the global context
+    assert event._metadata.environment == "global_env"
+    assert event.context == {"other": "value"}
+
+
+def test_no_environment_in_any_context(event_data):
+    # No environment value set in any context
+    global_context = {"other": "value_global"}
+    stored_context = {"other": "value_stored"}
+
+    # Simulate setting stored context
+    state.store(state.State.CONTEXT_ID, stored_context)
+
+    # Simulate a global context hook
+    config.Config.event_context_hook = lambda: global_context
+
+    # Now create an Event without an environment
+    event = core.Event(**event_data)
+
+    # The environment should remain None as set in the fixture
+    assert event._metadata.environment is None
+    # Verify context merging without 'environment' key
+    assert event.context == {"other": "value_stored"}
+
+
+def test_no_environment_from_config():
+    # No environment value set in any context
+    global_context = {"other": "value_global"}
+    stored_context = {"other": "value_stored"}
+
+    # Simulate setting stored context
+    state.store(state.State.CONTEXT_ID, stored_context)
+
+    # Simulate a global context hook
+    config.Config.environment = "config_env"
+    config.Config.event_context_hook = lambda: global_context
+
+    # Create an Event now that environment is set in config
+    event = core.Event(
+        **{
+            "event_type": "test_event",
+            "_metadata": core.Metadata(function_fingerprint="test_fingerprint"),
+        }
+    )
+
+    assert event._metadata.environment == "config_env"
+    # Verify context merging without 'environment' key
+    assert event.context == {"other": "value_stored"}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,135 @@
+import pytest
+
+from rosnik import config
+from rosnik import state
+from rosnik.types import core
+
+# Setup the fixture for Event data
+@pytest.fixture
+def event_data(mocker):
+    return {
+        "event_type": "test_event",
+        "_metadata": mocker.MagicMock()
+    }
+
+# Fixture to reset the context after each test to avoid side effects
+@pytest.fixture(autouse=True)
+def reset_state():
+    state._reset()
+    yield
+    state._reset()
+
+def test_post_init_without_contexts(event_data):
+    # Assuming no context is set, no global context should be added.
+    event = core.Event(**event_data)
+    assert event.context is None
+
+def test_post_init_with_context(event_data):
+    # Set a context value using the state management functions
+    context = {'key': 'value'}
+    state.store(state.State.CONTEXT_ID, context)
+    
+    event = core.Event(**event_data)
+    assert event.context == context
+
+def test_event_context_overrides_stored_and_global(event_data):
+    # Set a stored context and a global context hook
+    stored_context = {'shared': 'stored', 'unique_stored': 'value_stored'}
+    global_context = {'shared': 'global', 'unique_global': 'value_global'}
+    event_context = {'shared': 'event', 'unique_event': 'value_event'}
+    
+    # Simulate setting stored context
+    state.store(state.State.CONTEXT_ID, stored_context)
+    
+    # Simulate a global context hook
+    config.Config.event_context_hook = lambda: global_context
+    
+    # Now create an Event with an event-specific context
+    event = core.Event(**event_data, context=event_context)
+    
+    # The event's context should have 'event' as the 'shared' value
+    expected_context = {'shared': 'event', 'unique_global': 'value_global', 'unique_stored': 'value_stored', 'unique_event': 'value_event'}
+    assert event.context == expected_context
+
+def test_stored_context_overrides_global(event_data):
+    # Set a stored context and a global context hook
+    stored_context = {'shared': 'stored', 'unique_stored': 'value_stored'}
+    global_context = {'shared': 'global', 'unique_global': 'value_global'}
+    
+    # Simulate setting stored context
+    state.store(state.State.CONTEXT_ID, stored_context)
+    
+    # Simulate a global context hook
+    config.Config.event_context_hook = lambda: global_context
+    
+    # Now create an Event without an event-specific context
+    event = core.Event(**event_data)
+    
+    # The event's context should have 'stored' as the 'shared' value
+    expected_context = {'shared': 'stored', 'unique_global': 'value_global', 'unique_stored': 'value_stored'}
+    assert event.context == expected_context
+
+def test_global_context_applied_when_no_other(event_data):
+    # Set a global context hook only
+    global_context = {'shared': 'global', 'unique_global': 'value_global'}
+    
+    # Simulate a global context hook
+    config.Config.event_context_hook = lambda: global_context
+    
+    # Now create an Event without an event-specific or stored context
+    event = core.Event(**event_data)
+    
+    # The event's context should be just the global context
+    assert event.context == global_context
+
+def test_no_contexts_results_in_none(event_data):
+    # Assuming no contexts are set anywhere
+    # Simulate a global context hook that returns None
+    config.Config.event_context_hook = lambda: None
+    
+    # Now create an Event without any context
+    event = core.Event(**event_data)
+    
+    # The event's context should be None
+    assert event.context is None
+
+def test_post_init_with_journey_id(event_data):
+    # Set a journey ID using the state management functions
+    journey_id = state.create_journey_id()
+    
+    event = core.Event(**event_data)
+    assert event.journey_id == journey_id
+
+def test_post_init_with_user_interaction_id(event_data):
+    # Set a user interaction ID using the state management functions
+    user_interaction_id = "interaction_123"
+    state.store(state.State.USER_INTERACTION_ID, user_interaction_id)
+    
+    event = core.Event(**event_data)
+    assert event.user_interaction_id == user_interaction_id
+
+def test_post_init_with_device_id(event_data):
+    # Set a device ID using the state management functions
+    device_id = "device_123"
+    state.store(state.State.DEVICE_ID, device_id)
+    
+    event = core.Event(**event_data)
+    assert event.device_id == device_id
+
+def test_post_init_with_all_states(event_data):
+    # Set up all states using the state management functions
+    context = {'key': 'value'}
+    journey_id = state.create_journey_id()
+    user_interaction_id = "interaction_123"
+    device_id = "device_123"
+    
+    state.store(state.State.CONTEXT_ID, context)
+    state.store(state.State.USER_INTERACTION_ID, user_interaction_id)
+    state.store(state.State.DEVICE_ID, device_id)
+    
+    event = core.Event(**event_data)
+    # The event's context should contain the context set up above
+    assert event.context == context
+    assert event.journey_id == journey_id
+    assert event.user_interaction_id == user_interaction_id
+    assert event.device_id == device_id


### PR DESCRIPTION
This allows developers to set event-level context closer to where the event is emitted. 

`event.context` has the highest precedence, followed by context in `state`, and finally followed by context from `config.event_context_hook`.

The way we manage context is through a `ContextVar`. Our context manager (`rosnik.context`) holds on to the last token and resets it on exit. This allows us to chain together multiple event-level contexts if necessary. Embedded context managers have their own context -- the values are not unioned across context managers' scopes.

It can be used like:

```py
with rosnik.context(prompt_label="test-label"):
      # context = {"prompt_label": "test-label"}  
      openai.ChatCompletion.create(
            model="gpt-3.5-turbo",
            messages=expected_messages,
        )

        with rosnik.context(prompt_label="test-label2"):
            # {"prompt_label": "test-label2"}
            openai.ChatCompletion.create(
                model="gpt-3.5-turbo",
                messages=expected_messages,
            )

        # {"prompt_label": "test-label"}
        openai.ChatCompletion.create(
            model="gpt-3.5-turbo",
            messages=expected_messages,
        )

# no context
openai.ChatCompletion.create(
    model="gpt-3.5-turbo",
    messages=expected_messages,
)
```

As a part of this, how we process "environment" has also changed such that any of these contexts can now contain "environment" as a key, and we will pull it into `_metadata` as appropriate. This follows the same precedence as above, although I suspect in most cases, environment will be set at the global hook level, through environment variables, or on initialization.